### PR TITLE
RTSP計測中の警告をプラグイン名グループに表示

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -141,6 +141,8 @@ RtspE2eResultFmt="Median: %.0f ms (min: %.0f / max: %.0f)"
 RtspE2eMeasuring="Measuring..."
 RtspE2eHintStartStreaming="Start streaming in OBS"
 RtspE2eHintWsMeasuring="WS measurement in progress"
+RtspMeasureWarnMute="Stream is muted during measurement"
+RtspMeasureWarnMix="Measurement signals are mixed into the stream"
 RtspE2eFailed="Measurement failed"
 RtspE2eError="Measurement failed: "
 

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -142,6 +142,8 @@ RtspE2eResultFmt="中央値: %.0f ms（最小: %.0f / 最大: %.0f）"
 RtspE2eMeasuring="計測中..."
 RtspE2eHintStartStreaming="OBSの配信を開始してください"
 RtspE2eHintWsMeasuring="WS計測中です"
+RtspMeasureWarnMute="計測中は配信がミュートされます"
+RtspMeasureWarnMix="計測中は配信に計測シグナルが混じります"
 RtspE2eFailed="計測失敗"
 RtspE2eError="計測失敗: "
 

--- a/src/ui/properties-builder.cpp
+++ b/src/ui/properties-builder.cpp
@@ -1102,6 +1102,16 @@ namespace ods::ui {
 		}
 
 		if (!d->is_warning_only_instance()) {
+			// RTSP 計測中の警告（計測モードに応じたテキスト）
+			if (d->rtsp_e2e_measure.is_measuring()) {
+				const bool  probe_mute = d->probe_mute_active.load(std::memory_order_acquire);
+				const char *warn_text  = probe_mute ? T_("RtspMeasureWarnMute")
+				                                    : T_("RtspMeasureWarnMix");
+				obs_property_t *rtsp_warn_p = obs_properties_add_text(
+					grp, "rtsp_measure_warning", warn_text, OBS_TEXT_INFO);
+				obs_property_text_set_info_word_wrap(rtsp_warn_p, true);
+			}
+
 			const bool  ws_on     = d->router_running.load();
 			const bool  ws_paused = !d->ws_send_enabled.load();
 			const bool  ws_no_dly = !d->enabled.load();


### PR DESCRIPTION
## 概要

- RTSP 計測中に、プラグイン名グループ（ヘッダー領域）へ計測モードに応じた警告テキストを表示する
- ミュートモード: 「計測中は配信がミュートされます」
- ミックスモード: 「計測中は配信に計測シグナルが混じります」

## テスト計画

- [ ] ミュートモードで RTSP 計測を開始し、ヘッダーに「計測中は配信がミュートされます」が表示されることを確認
- [ ] ミックスモードで RTSP 計測を開始し、ヘッダーに「計測中は配信に計測シグナルが混じります」が表示されることを確認
- [ ] 計測終了後に警告が消えることを確認
- [ ] 非計測時にヘッダーに警告が表示されないことを確認

https://claude.ai/code/session_01LuiisELYMHygC1dx17Ybhy