### PR TITLE
Add tunnel assigned domain display to plugin properties

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -14,6 +14,7 @@ AudioSyncOffsetWarning="<span style='background-color:#FF0000; color:#FFFFFF; fo
 UpdateAvailableNoticeFmt="<a href='https://github.com/MZ1987Records/obs-delay-stream/releases' style='background-color:#1E7F34; color:#FFFFFF; font-weight:700; padding:2px 4px;'>A new version v%s is available</a>"
 PluginWsStatusLabel="WS Server"
 PluginTunnelStatusLabel="Tunnel"
+PluginTunnelDomainLabel="Tunnel assigned domain"
 SettingsMismatchWarning="The data version differs or the settings are inconsistent. Remove this filter and create it again."
 
 # Tab selector

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -15,6 +15,7 @@ ObsVersionWarning="<span style='background-color:#FF0000; color:#FFFFFF; font-we
 UpdateAvailableNoticeFmt="<a href='https://github.com/MZ1987Records/obs-delay-stream/releases' style='background-color:#1E7F34; color:#FFFFFF; font-weight:700; padding:2px 4px;'>新しいバージョン v%s が利用可能です</a>"
 PluginWsStatusLabel="WSサーバー"
 PluginTunnelStatusLabel="トンネル"
+PluginTunnelDomainLabel="トンネル割当ドメイン"
 SettingsMismatchWarning="データのバージョンが異なるか、または不整合があります。このフィルタを削除し、再作成してください。"
 
 # Tab selector

--- a/src/ui/properties-builder.cpp
+++ b/src/ui/properties-builder.cpp
@@ -1153,6 +1153,29 @@ namespace ods::ui {
 				obs_properties_add_text(grp, "plugin_status_info", "", OBS_TEXT_INFO);
 			obs_property_set_long_description(status_p, status_html.c_str());
 			obs_property_text_set_info_word_wrap(status_p, false);
+
+			// トンネル割当ドメイン
+			{
+				std::string turl   = d->tunnel.url();
+				std::string domain = extract_host_from_url(turl);
+				const char *domain_text;
+				if (d->tunnel.cloudflared_downloading() ||
+					d->manual_cloudflared_download_running.load(std::memory_order_acquire)) {
+					domain_text = T_("CloudflaredDownloading");
+				} else if (ts_plugin == TunnelState::Starting) {
+					domain_text = T_("TunnelStarting");
+				} else if (!domain.empty()) {
+					domain_text = domain.c_str();
+				} else {
+					domain_text = T_("TunnelUnassignedDomain");
+				}
+				std::string tunnel_domain_html = string_printf(
+					"<b>%s</b>: %s", T_("PluginTunnelDomainLabel"), domain_text);
+				obs_property_t *tdom_p = obs_properties_add_text(
+					grp, "plugin_tunnel_domain_info", "", OBS_TEXT_INFO);
+				obs_property_set_long_description(tdom_p, tunnel_domain_html.c_str());
+				obs_property_text_set_info_word_wrap(tdom_p, false);
+			}
 		}
 
 		obs_properties_add_group(props, "grp_plugin", T_("Plugin"), OBS_GROUP_NORMAL, grp);


### PR DESCRIPTION
## Summary
This PR adds a new information field to the plugin properties UI that displays the tunnel's assigned domain. The domain is extracted from the tunnel URL and shows different status messages depending on the tunnel state.

## Key Changes
- Added a new "Tunnel assigned domain" info field to the plugin properties group in `properties-builder.cpp`
- The field displays:
  - "CloudflaredDownloading" status when cloudflared is being downloaded
  - "TunnelStarting" status when the tunnel is starting
  - The actual domain name when available
  - "TunnelUnassignedDomain" when no domain is assigned
- Added localization strings for the new field in both English (`en-US.ini`) and Japanese (`ja-JP.ini`) locale files

## Implementation Details
- The domain is extracted from the tunnel URL using the existing `extract_host_from_url()` function
- The implementation checks multiple conditions to determine the appropriate status text to display
- The field is rendered as an info-type property with HTML formatting (bold label) and word wrapping disabled, consistent with the existing tunnel status field

https://claude.ai/code/session_01ShLBnRb7dbKvDNfWGpBb3E